### PR TITLE
Handle responses larger than 4096 bytes

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -272,6 +272,7 @@ func (p *Proxy) HandleConnection(client net.Conn) {
 			 * Continue to read from the backend until a 'ReadyForQuery' message is
 			 * is found.
 			 */
+			offset := 0
 			for !done {
 				if message, length, err = connect.Receive(backend); err != nil {
 					log.Debugf("Error receiving response from backend %s", backend.RemoteAddr())
@@ -280,12 +281,13 @@ func (p *Proxy) HandleConnection(client net.Conn) {
 				}
 
 				messageType := protocol.GetMessageType(message[:length])
+				overflow := 0
 
 				/*
 				 * Examine all of the messages in the buffer and determine if any of
 				 * them are a ReadyForQuery message.
 				 */
-				for start := 0; start < length; {
+				for start := offset; start < length; {
 					messageType = protocol.GetMessageType(message[start:])
 					messageLength := protocol.GetMessageLength(message[start:])
 
@@ -293,7 +295,18 @@ func (p *Proxy) HandleConnection(client net.Conn) {
 					 * Calculate the next start position, add '1' to the message
 					 * length to account for the message type.
 					 */
-					start = (start + int(messageLength) + 1)
+					start = start + int(messageLength) + 1
+
+					overflow = start - length
+				}
+
+				/*
+				 * As per https://www.postgresql.org/docs/12/protocol-overview.html,
+				 * use the message byte count to allow for messages that span multiple
+				 * receives from the server.
+				 */
+				if overflow > 0 {
+					offset = overflow
 				}
 
 				if _, err = connect.Send(client, message[:length]); err != nil {
@@ -302,7 +315,7 @@ func (p *Proxy) HandleConnection(client net.Conn) {
 					done = true
 				}
 
-				done = (messageType == protocol.ReadyForQueryMessageType)
+				done = (messageType == protocol.ReadyForQueryMessageType && overflow <= 0)
 			}
 
 			/*

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -288,6 +288,10 @@ func (p *Proxy) HandleConnection(client net.Conn) {
 				 * them are a ReadyForQuery message.
 				 */
 				for start := offset; start < length; {
+					if len(message[start:]) < 5 {
+						// The message length doesn't fit in this chunk; stop reading
+						break
+					}
 					messageType = protocol.GetMessageType(message[start:])
 					messageLength := protocol.GetMessageLength(message[start:])
 


### PR DESCRIPTION
When running the proxy I encountered situations where connections would stall without an error. I tracked this down to the proxy not handling the case where a message spanned multiple receive buffers (response is greater than 4096 bytes). The proxy lost synchronization with the message boundaries, and therefore did not detect the ReadyForQuery message.

This change accounts for such cases.

Something that should be looked at is a timeout for the backend receive. Currently a message misalignment permanently locks a connection, and a timeout could have eventually terminated and freed it.